### PR TITLE
Support for Django 1.4+ time-zone-aware datetimes.

### DIFF
--- a/tracking/middleware.py
+++ b/tracking/middleware.py
@@ -13,6 +13,11 @@ from django.http import Http404
 from tracking import utils
 from tracking.models import Visitor, UntrackedUserAgent, BannedIP
 
+try:
+    from django.utils.timezone import now as right_now
+except ImportError:
+    right_now = datetime.now
+
 title_re = re.compile('<title>(.*?)</title>')
 log = logging.getLogger('tracking.middleware')
 
@@ -93,7 +98,7 @@ class VisitorTrackingMiddleware(object):
 
         # if we get here, the URL needs to be tracked
         # determine what time it is
-        now = datetime.now()
+        now = right_now()
 
         attrs = {
             'session_key': session_key,
@@ -159,7 +164,7 @@ class VisitorCleanUpMiddleware:
 
         if str(timeout).isdigit():
             log.debug('Cleaning up visitors older than %s hours' % timeout)
-            timeout = datetime.now() - timedelta(hours=int(timeout))
+            timeout = right_now() - timedelta(hours=int(timeout))
             Visitor.objects.filter(last_update__lte=timeout).delete()
 
 class BannedIPMiddleware:

--- a/tracking/models.py
+++ b/tracking/models.py
@@ -13,6 +13,11 @@ from django.db import models
 from django.utils.translation import ugettext, ugettext_lazy as _
 from tracking import utils
 
+try:
+    from django.utils.timezone import now as right_now
+except ImportError:
+    right_now = datetime.now
+
 USE_GEOIP = getattr(settings, 'TRACKING_USE_GEOIP', False)
 CACHE_TYPE = getattr(settings, 'GEOIP_CACHE_TYPE', 4)
 
@@ -27,7 +32,7 @@ class VisitorManager(models.Manager):
         if not timeout:
             timeout = utils.get_timeout()
 
-        now = datetime.now()
+        now = right_now()
         cutoff = now - timedelta(minutes=timeout)
 
         return self.get_query_set().filter(last_update__gte=cutoff)

--- a/tracking/views.py
+++ b/tracking/views.py
@@ -12,6 +12,11 @@ from django.views.decorators.cache import never_cache
 from tracking.models import Visitor
 from tracking.utils import u_clean as uc
 
+try:
+    from django.utils.timezone import now as right_now
+except ImportError:
+    right_now = datetime.now
+
 DEFAULT_TRACKING_TEMPLATE = getattr(settings, 'DEFAULT_TRACKING_TEMPLATE',
                                     'tracking/visitor_map.html')
 log = logging.getLogger('tracking.views')
@@ -49,7 +54,7 @@ def get_active_users(request):
     """
     if request.is_ajax():
         active = Visitor.objects.active().reverse()
-        now = datetime.now()
+        now = right_now()
 
         # we don't put the session key or IP address here for security reasons
         try:


### PR DESCRIPTION
When using tracking with Django 1.4+ with USE_TZ set to True, comparisons are attempted between time-zone-aware and time-zone-naive datetimes due to tracking's use of datetime.now(), which raises an exception. My updates use django.utils.timezone.now() when available (when running Django 1.4+), falling back to the old method otherwise. So, this shouldn't break any sites already using tracking, and adds support for sites using Django 1.4+ with time-zone-aware datetimes.
