### PR TITLE
Support for Django >= 1.5

### DIFF
--- a/tracking/__init__.py
+++ b/tracking/__init__.py
@@ -1,5 +1,3 @@
-import listeners
-
 VERSION = (0, 4, 0)
 
 def get_version():


### PR DESCRIPTION
Remove import of listeners which causes install to fail with Django >= 1.5
